### PR TITLE
Kubeadm role add

### DIFF
--- a/ansible/roles/bootstrap_os/tasks/micro_os/prepare_kubic.yml
+++ b/ansible/roles/bootstrap_os/tasks/micro_os/prepare_kubic.yml
@@ -4,7 +4,6 @@
   ansible.posix.sysctl:
     name: 'kernel.hostname'
     value: '{{ inventory_hostname }}'
-    sysctl_file: '/etc/sysctl.d/85-hostname-sysctl.conf'
     reload: false
     state: 'present'
   notify: restart systemd-sysctl

--- a/ansible/roles/kubeadm/defaults/main.yml
+++ b/ansible/roles/kubeadm/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+
+kubernetes_role: master
+
+kubernetes_kubelet_extra_args: ""
+kubernetes_kubeadm_init_extra_opts: ""
+kubernetes_join_command_extra_opts: ""
+
+kubernetes_apiserver_advertise_address: ''
+
+kubernetes_control_plane_endpoint:
+  address: ' {{ ansible_default_ipv4.address }}'
+  port: '6443'
+
+kubernetes_pod_network:
+  cidr: '10.244.0.0/16'

--- a/ansible/roles/kubeadm/handlers/main.yml
+++ b/ansible/roles/kubeadm/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: 'pre checks'
+  ansible.builtin.include_tasks: preflight_checks.yml

--- a/ansible/roles/kubeadm/tasks/main.yml
+++ b/ansible/roles/kubeadm/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- include_tasks: preflight_checks.yml
+
+- include_tasks: prepare_k8s.yml
+
+- include_tasks: master_setup.yml
+  when:
+    - kubernetes_role == 'master'
+
+- name: 'get the kubeadm join command from the Kubernetes master.'
+  command: kubeadm token create --print-join-command
+  changed_when: false
+  when: kubernetes_role == 'master'
+  register: kubernetes_join_command_result
+
+- name: 'set the kubeadm join command globally'
+  ansible.builtin.set_fact:
+    kubernetes_join_command: '{{ kubernetes_join_command_result.stdout }} {{ kubernetes_join_command_extra_opts }}'
+  when: kubernetes_join_command_result.stdout is defined
+  delegate_to: '{{ item }}'
+  delegate_facts: true
+  with_items: "{{ groups['all'] }}"
+
+- include_tasks: worker-setup.yml
+  when:
+    - kubernetes_role == 'worker'
+    - not cluster_node_active

--- a/ansible/roles/kubeadm/tasks/main.yml
+++ b/ansible/roles/kubeadm/tasks/main.yml
@@ -8,19 +8,11 @@
   when:
     - kubernetes_role == 'master'
 
-- name: 'get the kubeadm join command from the Kubernetes master.'
-  command: kubeadm token create --print-join-command
-  changed_when: false
-  when: kubernetes_role == 'master'
-  register: kubernetes_join_command_result
-
-- name: 'set the kubeadm join command globally'
-  ansible.builtin.set_fact:
-    kubernetes_join_command: '{{ kubernetes_join_command_result.stdout }} {{ kubernetes_join_command_extra_opts }}'
-  when: kubernetes_join_command_result.stdout is defined
-  delegate_to: '{{ item }}'
-  delegate_facts: true
-  with_items: "{{ groups['all'] }}"
+- name: Copy Kubernetes config locally
+  fetch:
+    dest: output/k8s-config.yaml
+    flat: true
+    src: /etc/kubernetes/admin.conf
 
 - include_tasks: worker-setup.yml
   when:

--- a/ansible/roles/kubeadm/tasks/main.yml
+++ b/ansible/roles/kubeadm/tasks/main.yml
@@ -7,12 +7,16 @@
 - include_tasks: master_setup.yml
   when:
     - kubernetes_role == 'master'
+    - not cluster_node_active
 
 - name: Copy Kubernetes config locally
+  run_once: true
   fetch:
     dest: output/k8s-config.yaml
     flat: true
     src: /etc/kubernetes/admin.conf
+  when:
+    - kubernetes_role == 'master'
 
 - include_tasks: worker-setup.yml
   when:

--- a/ansible/roles/kubeadm/tasks/master_setup.yml
+++ b/ansible/roles/kubeadm/tasks/master_setup.yml
@@ -5,60 +5,47 @@
   register: kubeadm_images
   changed_when: '"pulled" in kubeadm_images.stdout'
 
-- name: 'initalize Kubernetes control-plane'
-  block:
+- name: 'initalize control plane'
+  run_once: true
+  command: >
+    kubeadm init
+    --pod-network-cidr={{ kubernetes_pod_network.cidr }}
+    --control-plane-endpoint={{ kubernetes_control_plane_endpoint.address }}:{{ kubernetes_control_plane_endpoint.port }}
+    {{ kubernetes_kubeadm_init_extra_opts }}
+  when: not cluster_node_active
+  register: kubeadm_join
+  notify: pre checks
 
-  - name: 'initalize control plane'
-    throttle: 1
-    command: >
-      kubeadm init
-      --pod-network-cidr={{ kubernetes_pod_network.cidr }}
-      --control-plane-endpoint={{ kubernetes_control_plane_endpoint.address }}:{{ kubernetes_control_plane_endpoint.port }}
-      {{ kubernetes_kubeadm_init_extra_opts }}
-    when: not cluster_node_active
-    register: kubeadm_join
+- name: flush handlers
+  meta: flush_handlers
 
-  rescue:
+- name: 'upload certificates from control plane'
+  command: kubeadm init phase upload-certs --upload-certs
+  register: kubeadm_controlplane_certs
+  when: cluster_node_active
 
-  - name: 'kubeadm reset'
-    command: 'kubeadm reset --force'
+- name: 'set certificate key fact'
+  ansible.builtin.set_fact:
+    control_plane_key: "{{ kubeadm_controlplane_certs.stdout_lines[2] }}"
+  when: cluster_node_active
 
-  - name: 'upload certificates from control plane'
-    command: kubeadm init phase upload-certs --upload-certs
-    register: kubeadm_controlplane_certs
-    when: cluster_node_active
+- name: 'get control plane kubeadm join command'
+  command: kubeadm token create --print-join-command --certificate-key {{ control_plane_key }}
+  register: kubernetes_control_plane_join_command_result
+  when: cluster_node_active
 
-  - name: 'set certificate key fact'
-    ansible.builtin.set_fact:
-      control_plane_key: kubeadm_controlplane_certs.stdout_lines[2]
-    when: cluster_node_active
+- name: 'set fact for kubeadm join command on control plane nodes globally'
+  ansible.builtin.set_fact:
+    kubernetes_control_plane_join_command: "{{ kubernetes_control_plane_join_command_result.stdout }}"
+  delegate_facts: true
+  delegate_to: '{{ item }}'
+  with_items: "{{ groups['all'] }}"
+  when: cluster_node_active
 
-  - name: 'get control plane kubeadm join command'
-    command: kubeadm token create --print-join-command --certificate-key {{ control_plane_key }}
-    register: kubernetes_control_plane_join_command_result
-    when: cluster_node_active
-
-  - name: 'set fact for kubeadm join command on control plane nodes globally'
-    ansible.builtin.set_fact:
-      kubernetes_control_plane_join_command: kubernetes_control_plane_join_command_result.stdout
-    delegate_facts: true
-    delegate_to: '{{ item }}'
-    with_items: "{{ groups['all'] }}"
-    when: cluster_node_active
-
-  - name: 'join remaining control plane nodes'
-    command: '{{ kubernetes_control_plane_join_command }}'
-    register: kubeadm_join
-    when: not cluster_node_active
-
-  always:
-
-  - name: 'display kubeadm join error'
-    when: kubeadm_join is failed
-    debug:
-      msg: |
-        Joined with warnings
-        {{ kubeadm_join.stderr_lines }}
+- name: 'join remaining control plane nodes'
+  command: '{{ kubernetes_control_plane_join_command }}'
+  register: kubeadm_join
+  when: not cluster_node_active
 
 - name: 'symlink the kubectl admin.conf to ~/.kube/conf'
   file:

--- a/ansible/roles/kubeadm/tasks/master_setup.yml
+++ b/ansible/roles/kubeadm/tasks/master_setup.yml
@@ -4,16 +4,19 @@
   command: kubeadm config images pull
   register: kubeadm_images
   changed_when: '"pulled" in kubeadm_images.stdout'
+  when: not cluster_node_active
 
 - name: 'initalize control plane'
-  run_once: true
   command: >
     kubeadm init
     --pod-network-cidr={{ kubernetes_pod_network.cidr }}
     --control-plane-endpoint={{ kubernetes_control_plane_endpoint.address }}:{{ kubernetes_control_plane_endpoint.port }}
     {{ kubernetes_kubeadm_init_extra_opts }}
-  when: not cluster_node_active
+  when:
+    - not cluster_node_active
+    - not control_plane_exists
   register: kubeadm_join
+  run_once: true
   notify: pre checks
 
 - name: flush handlers
@@ -22,16 +25,19 @@
 - name: 'upload certificates from control plane'
   command: kubeadm init phase upload-certs --upload-certs
   register: kubeadm_controlplane_certs
+  run_once: true
   when: cluster_node_active
 
 - name: 'set certificate key fact'
   ansible.builtin.set_fact:
     control_plane_key: "{{ kubeadm_controlplane_certs.stdout_lines[2] }}"
+  run_once: true
   when: cluster_node_active
 
 - name: 'get control plane kubeadm join command'
   command: kubeadm token create --print-join-command --certificate-key {{ control_plane_key }}
   register: kubernetes_control_plane_join_command_result
+  run_once: true
   when: cluster_node_active
 
 - name: 'set fact for kubeadm join command on control plane nodes globally'

--- a/ansible/roles/kubeadm/tasks/master_setup.yml
+++ b/ansible/roles/kubeadm/tasks/master_setup.yml
@@ -1,0 +1,68 @@
+---
+
+- name: 'pull control plane images'
+  command: kubeadm config images pull
+  register: kubeadm_images
+  changed_when: '"pulled" in kubeadm_images.stdout'
+
+- name: 'initalize Kubernetes control-plane'
+  block:
+
+  - name: 'initalize control plane'
+    throttle: 1
+    command: >
+      kubeadm init
+      --pod-network-cidr={{ kubernetes_pod_network.cidr }}
+      --control-plane-endpoint={{ kubernetes_control_plane_endpoint.address }}:{{ kubernetes_control_plane_endpoint.port }}
+      {{ kubernetes_kubeadm_init_extra_opts }}
+    when: not cluster_node_active
+    register: kubeadm_join
+
+  rescue:
+
+  - name: 'kubeadm reset'
+    command: 'kubeadm reset --force'
+
+  - name: 'upload certificates from control plane'
+    command: kubeadm init phase upload-certs --upload-certs
+    register: kubeadm_controlplane_certs
+    when: cluster_node_active
+
+  - name: 'set certificate key fact'
+    ansible.builtin.set_fact:
+      control_plane_key: kubeadm_controlplane_certs.stdout_lines[2]
+    when: cluster_node_active
+
+  - name: 'get control plane kubeadm join command'
+    command: kubeadm token create --print-join-command --certificate-key {{ control_plane_key }}
+    register: kubernetes_control_plane_join_command_result
+    when: cluster_node_active
+
+  - name: 'set fact for kubeadm join command on control plane nodes globally'
+    ansible.builtin.set_fact:
+      kubernetes_control_plane_join_command: kubernetes_control_plane_join_command_result.stdout
+    delegate_facts: true
+    delegate_to: '{{ item }}'
+    with_items: "{{ groups['all'] }}"
+    when: cluster_node_active
+
+  - name: 'join remaining control plane nodes'
+    command: '{{ kubernetes_control_plane_join_command }}'
+    register: kubeadm_join
+    when: not cluster_node_active
+
+  always:
+
+  - name: 'display kubeadm join error'
+    when: kubeadm_join is failed
+    debug:
+      msg: |
+        Joined with warnings
+        {{ kubeadm_join.stderr_lines }}
+
+- name: 'symlink the kubectl admin.conf to ~/.kube/conf'
+  file:
+    src: /etc/kubernetes/admin.conf
+    dest: ~/.kube/config
+    state: link
+    mode: 0644

--- a/ansible/roles/kubeadm/tasks/preflight_checks.yml
+++ b/ansible/roles/kubeadm/tasks/preflight_checks.yml
@@ -8,3 +8,11 @@
 - name: set node status fact
   ansible.builtin.set_fact:
     cluster_node_active: "{{ k8s_kubelet_conf.stat.exists }}"
+
+- name: set control plane exists fact
+  ansible.builtin.set_fact:
+    control_plane_exists: "{{ k8s_kubelet_conf.stat.exists }}"
+  when: k8s_kubelet_conf.stat.exists
+  delegate_to: '{{ item }}'
+  delegate_facts: true
+  with_items: "{{ groups['all'] }}"

--- a/ansible/roles/kubeadm/tasks/preflight_checks.yml
+++ b/ansible/roles/kubeadm/tasks/preflight_checks.yml
@@ -1,0 +1,10 @@
+---
+
+- name: check node status
+  stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: k8s_kubelet_conf
+
+- name: set node status fact
+  ansible.builtin.set_fact:
+    cluster_node_active: "{{ k8s_kubelet_conf.stat.exists }}"

--- a/ansible/roles/kubeadm/tasks/prepare_k8s.yml
+++ b/ansible/roles/kubeadm/tasks/prepare_k8s.yml
@@ -1,0 +1,47 @@
+---
+
+- name: 'ensure kubernetes manifests directory'
+  ansible.builtin.file:
+    path: '/etc/kubernetes/manifests'
+    state: 'directory'
+
+- name: 'ensure kubelet is running and enabled'
+  ansible.builtin.service:
+    name: kubelet
+    state: started
+    enabled: true
+
+- name: 'ensure required modules are loaded'
+  community.general.modprobe:
+    name: '{{ item }}'
+    state: 'present'
+  loop:
+  - 'overlay'
+  - 'br_netfilter'
+
+- name: 'ensure required modules load at system startup'
+  ansible.builtin.copy:
+    dest: '/etc/modules-load.d/kubernetes-modules.conf'
+    content: |
+      overlay
+      br_netfilter
+
+- name: 'ensure sysctl options are configured for container runtime'
+  ansible.posix.sysctl:
+    name: '{{ item }}'
+    value: '1'
+    state: 'present'
+    sysctl_file: '/etc/sysctl.d/99-kubernetes-sysctl.conf'
+    reload: false
+  loop:
+  - net.bridge.bridge-nf-call-iptables
+  - net.bridge.bridge-nf-call-ip6tables
+  - net.ipv4.ip_forward
+  notify: restart systemd-sysctl
+
+- name: 'ensure .kube exists'
+  file:
+    path: ~/.kube
+    state: directory
+    mode: 0755
+  when: kubernetes_role == 'master'

--- a/ansible/roles/kubeadm/tasks/worker-setup.yml
+++ b/ansible/roles/kubeadm/tasks/worker-setup.yml
@@ -1,6 +1,22 @@
 ---
 
-- name: 'join node to Kubernetes master'
-  shell: >
-    {{ kubernetes_join_command }}
-    creates=/etc/kubernetes/kubelet.conf
+- name: 'get the kubeadm join command from the Kubernetes master.'
+  command: kubeadm token create --print-join-command
+  changed_when: false
+  when: kubernetes_role == 'master'
+  register: kubernetes_join_command_result
+
+- name: 'set the kubeadm join command globally'
+  ansible.builtin.set_fact:
+    kubernetes_join_command: '{{ kubernetes_join_command_result.stdout }} {{ kubernetes_join_command_extra_opts }}'
+  when: kubernetes_join_command_result.stdout is defined
+  delegate_to: '{{ item }}'
+  delegate_facts: true
+  with_items: "{{ groups['all'] }}"
+
+- name: 'join worker to Kubernetes master'
+  command:
+    argv:
+      - {{ kubernetes_join_command }}
+      - {{ kubernetes_join_command_extra_opts }}
+    creates: /etc/kubernetes/kubelet.conf

--- a/ansible/roles/kubeadm/tasks/worker-setup.yml
+++ b/ansible/roles/kubeadm/tasks/worker-setup.yml
@@ -1,0 +1,6 @@
+---
+
+- name: 'join node to Kubernetes master'
+  shell: >
+    {{ kubernetes_join_command }}
+    creates=/etc/kubernetes/kubelet.conf


### PR DESCRIPTION
Minimum viable Kubeadm automation. For my own testing and validations.

I would recommend,

Kubespray or k8s-cluster-installation
. 

This helps with Kubeadm automation on Kubic. Trust sane defaults from upstream. (SUSE, and Kubernetes)
 