### PR TITLE
Kubeadm_cni role add

### DIFF
--- a/ansible/roles/kubeadm/defaults/main.yml
+++ b/ansible/roles/kubeadm/defaults/main.yml
@@ -4,7 +4,6 @@ kubernetes_role: master
 
 kubernetes_kubelet_extra_args: ""
 kubernetes_kubeadm_init_extra_opts: ""
-kubernetes_join_command_extra_opts: ""
 
 kubernetes_apiserver_advertise_address: ''
 

--- a/ansible/roles/kubeadm/tasks/main.yml
+++ b/ansible/roles/kubeadm/tasks/main.yml
@@ -18,6 +18,21 @@
   when:
     - kubernetes_role == 'master'
 
+- name: 'get the kubeadm join command from the Kubernetes master.'
+  command: kubeadm token create --print-join-command
+  changed_when: false
+  when:
+    - kubernetes_role == 'master'
+  register: kubernetes_join_command_result
+
+- name: 'set the kubeadm join command globally'
+  ansible.builtin.set_fact:
+    kubernetes_join_command: '{{ kubernetes_join_command_result.stdout }} {{ kubernetes_join_command_extra_opts }}'
+  when: kubernetes_join_command_result.stdout is defined
+  delegate_to: '{{ item }}'
+  delegate_facts: true
+  with_items: "{{ groups['all'] }}"
+
 - include_tasks: worker-setup.yml
   when:
     - kubernetes_role == 'worker'

--- a/ansible/roles/kubeadm/tasks/master_setup.yml
+++ b/ansible/roles/kubeadm/tasks/master_setup.yml
@@ -52,6 +52,7 @@
   command: '{{ kubernetes_control_plane_join_command }}'
   register: kubeadm_join
   when: not cluster_node_active
+  notify: pre checks
 
 - name: 'symlink the kubectl admin.conf to ~/.kube/conf'
   file:

--- a/ansible/roles/kubeadm/tasks/preflight_checks.yml
+++ b/ansible/roles/kubeadm/tasks/preflight_checks.yml
@@ -12,7 +12,6 @@
 - name: set control plane exists fact
   ansible.builtin.set_fact:
     control_plane_exists: "{{ k8s_kubelet_conf.stat.exists }}"
-  when: k8s_kubelet_conf.stat.exists
   delegate_to: '{{ item }}'
   delegate_facts: true
   with_items: "{{ groups['all'] }}"

--- a/ansible/roles/kubeadm/tasks/worker-setup.yml
+++ b/ansible/roles/kubeadm/tasks/worker-setup.yml
@@ -1,22 +1,6 @@
 ---
 
-- name: 'get the kubeadm join command from the Kubernetes master.'
-  command: kubeadm token create --print-join-command
-  changed_when: false
-  when: kubernetes_role == 'master'
-  register: kubernetes_join_command_result
-
-- name: 'set the kubeadm join command globally'
-  ansible.builtin.set_fact:
-    kubernetes_join_command: '{{ kubernetes_join_command_result.stdout }} {{ kubernetes_join_command_extra_opts }}'
-  when: kubernetes_join_command_result.stdout is defined
-  delegate_to: '{{ item }}'
-  delegate_facts: true
-  with_items: "{{ groups['all'] }}"
-
 - name: 'join worker to Kubernetes master'
   command:
-    argv:
-      - {{ kubernetes_join_command }}
-      - {{ kubernetes_join_command_extra_opts }}
+    cmd: "{{ kubernetes_join_command }}"
     creates: /etc/kubernetes/kubelet.conf

--- a/ansible/roles/kubeadm_cni/defualts/main.yml
+++ b/ansible/roles/kubeadm_cni/defualts/main.yml
@@ -1,0 +1,4 @@
+---
+cni_cilium_image_repository: docker.io/cilium/cilium-dev
+cni_cilium_helm_version: 1.9.3
+cni_cilium_image_version: v1.9.3

--- a/ansible/roles/kubeadm_cni/tasks/cilium.yml
+++ b/ansible/roles/kubeadm_cni/tasks/cilium.yml
@@ -1,0 +1,57 @@
+---
+
+# See https://github.com/cilium/cilium/issues/10645
+- name: 'set net.ipv4.conf.*.rp_filter to 0 for systemd 245 workaround'
+  ansible.posix.sysctl:
+    name: '{{ item }}'
+    value: '0'
+    sysctl_file: /etc/sysctl.d/98-override_cilium_rp_filter.conf
+    reload: false
+  loop:
+    - net.ipv4.conf.all.rp_filter
+    - net.ipv4.conf.default.rp_filter
+  notify: restart systemd-sysctl
+
+- name: 'mount sys-fs-bpf'
+  ansible.posix.mount:
+    path: /sys/fs/bpf
+    src: bpffs
+    opts: defaults
+    state: mounted
+    fstype: bpf
+
+- name: 'add cilium helm repo'
+  community.kubernetes.helm_repository:
+    name: cilium
+    repo_url: "https://helm.cilium.io/"
+
+- name: 'deploy cilium'
+  community.kubernetes.helm:
+    name: cilium
+    chart_ref: cilium/cilium
+    release_namespace: kube-system
+    chart_version: "{{ cni_cilium_helm_version }}"
+    values:
+      image:
+        repository: "{{ cni_cilium_image_repository }}"
+        tag: "{{ cni_cilium_image_version }}"
+      operator:
+        image:
+          repository: docker.io/cilium/operator-dev
+          tag: "{{ cni_cilium_image_version }}"
+
+- name: 'patch cilium-operator for helm chart bug'
+  community.kubernetes.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cilium-operator
+        namespace: kube-system
+      spec:
+        template:
+          spec:
+            containers:
+              - name: cilium-operator
+                image: cilium/operator-dev:{{ cni_cilium_image_version }}

--- a/ansible/roles/kubeadm_cni/tasks/main.yml
+++ b/ansible/roles/kubeadm_cni/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: setup {{ cni_plugin }} container network interface (cni)
+  include_tasks: "{{ cni_plugin }}.yml"
+  when:
+    - kubernetes_role == 'master'

--- a/clusters/nwk1/gitops/monitoring/thanos/thanos.yaml
+++ b/clusters/nwk1/gitops/monitoring/thanos/thanos.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes-charts.banzaicloud.com
       chart: thanos
-      version: 0.3.31
+      version: 0.4.0
       sourceRef:
         kind: HelmRepository
         name: banzaicloud-charts


### PR DESCRIPTION
This adds a higher opinionated role like k8s-cluster-installation for my own testing.

This reasoning for having this is finding the point where GitOps can pick up from the CNI installation. 

With multi-cluster support soonly being added to the repo it's better off to use this as a testing point.

Kubeadm fixes were also added. It creates a token every run. That should be fixed at some point but it's too minor to spend time on at the moment.

This only works for Cri-o + cilium and will likely be dropped at a later time.