### PR TITLE
Add minimum viable overlays for NWK1

### DIFF
--- a/gitops/namespaces/base/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/gitops/namespaces/base/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -73,6 +73,7 @@ spec:
         https: true
         insecureSkipVerify: true
     alertmanager:
+      enabled: false
       fullnameOverride: alertmanager
       ingress:
         enabled: true
@@ -92,6 +93,7 @@ spec:
                 requests:
                   storage: 10Gi
     grafana:
+      enabled: false
       fullnameOverride: grafana
       persistence:
         enabled: false
@@ -206,6 +208,7 @@ spec:
         access: proxy
         url: http://loki.monitoring.svc.cluster.local:3100
     prometheus:
+      enabled: false
       fullnameOverride: prometheus
       ingress:
         enabled: true

--- a/gitops/namespaces/base/monitoring/loki/loki.yaml
+++ b/gitops/namespaces/base/monitoring/loki/loki.yaml
@@ -95,7 +95,7 @@ spec:
         - source_labels: ['__syslog_message_hostname']
           target_label: 'host'
       syslogService:
-        enabled: true
+        enabled: false
         type: LoadBalancer
         port: 1514
         externalIPs:

--- a/gitops/namespaces/base/traefik/traefik/traefik.yaml
+++ b/gitops/namespaces/base/traefik/traefik/traefik.yaml
@@ -51,10 +51,4 @@ spec:
       - name: traefik-config
         mountPath: '/config'
         type: configMap
-    service:
-      externalIPs:
-        - 172.30.0.5
-        - 172.30.0.6
-        - 172.30.0.7
-      spec:
         externalTrafficPolicy: Local

--- a/gitops/namespaces/overlays/nwk1/patch.yaml
+++ b/gitops/namespaces/overlays/nwk1/patch.yaml
@@ -13,3 +13,33 @@ spec:
     prometheus:
       enabled: true
 ---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      syslogService:
+        enabled: true
+        type: LoadBalancer
+        port: 1514
+        externalIPs:
+        - 172.30.0.10
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  values:
+    service:
+      externalIPs:
+      - 172.30.0.5
+      - 172.30.0.6
+      - 172.30.0.7
+      spec:
+        externalTrafficPolicy: Local
+---

--- a/gitops/namespaces/overlays/nwk1/patch.yaml
+++ b/gitops/namespaces/overlays/nwk1/patch.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  values:
+    alertmanager:
+      enabled: true
+    grafana:
+      enabled: true
+    prometheus:
+      enabled: true
+---


### PR DESCRIPTION
This adds minimum viable overlays for NWK1. More should be removed from base and transferred into NWK1 though for the time being we'll use this to start.