### PR TITLE
Update the home stack

### DIFF
--- a/.github/workflows/scan-containers.yaml
+++ b/.github/workflows/scan-containers.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Scan Container
-        uses: aquasecurity/trivy-action@0.6.1
+        uses: aquasecurity/trivy-action@0.6.2
         with:
           image-ref: ${{ matrix.containers }}
           vuln-type: os,library

--- a/k8s/base/home/frigate/helm-release.yaml
+++ b/k8s/base/home/frigate/helm-release.yaml
@@ -24,7 +24,7 @@ spec:
     priorityClassName: system-node-critical
     image:
       repository: docker.io/blakeblackshear/frigate
-      tag: 0.11.0-beta7
+      tag: 0.11.0-rc1
     env:
       TZ: America/New_York
       FRIGATE_MQTT_PASSWORD:

--- a/k8s/base/home/home-assistant/helm-release.yaml
+++ b/k8s/base/home/home-assistant/helm-release.yaml
@@ -31,7 +31,7 @@ spec:
       backup.velero.io/backup-volumes: config
     image:
       repository: ghcr.io/home-assistant/home-assistant
-      tag: 2022.7.7
+      tag: 2022.8.1
     env:
       TZ: "America/New_York"
     envFrom:

--- a/k8s/base/infra/minecraft/database/postgres-db.yaml
+++ b/k8s/base/infra/minecraft/database/postgres-db.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 spec:
   replicas: 1
-  image: docker.io/library/postgres:13.7@sha256:b4e9da708faa812d4c77f7d60ece7a995248b4df530c9eab8b3ddca9364895c7
+  image: docker.io/library/postgres:13.7@sha256:b60110578f4882c1b0bd5049292fd40518cca8a9a592086c0beadde0da1dd533
   database:
     size: 20Gi
     storageClassName: ceph-block

--- a/k8s/base/infra/minecraft/database/postgres-db.yaml
+++ b/k8s/base/infra/minecraft/database/postgres-db.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 spec:
   replicas: 1
-  image: docker.io/library/postgres:13.7@sha256:b60110578f4882c1b0bd5049292fd40518cca8a9a592086c0beadde0da1dd533
+  image: docker.io/library/postgres:13.7@sha256:03652c675ae177af98ddd50f9f4b4b2cf8ad38d0e116aa68fe670fbc2cf250fc
   database:
     size: 20Gi
     storageClassName: ceph-block

--- a/k8s/base/media/prowlarr/helm-release.yaml
+++ b/k8s/base/media/prowlarr/helm-release.yaml
@@ -31,7 +31,7 @@ spec:
       backup.velero.io/backup-volumes: config
     image:
       repository: ghcr.io/onedr0p/prowlarr-nightly
-      tag: 0.4.4.1928@sha256:744b423e05a3e56f6d198cae77129ebbdff9e50ce76af931c41dc759ff3ca3c6        
+      tag: 0.4.4.1935@sha256:9df7d93a7af2dcff236c308e2278ea2e533e9f9257b5ada87e2178d54a8f3d85        
     env:
       TZ: "America/New_York"
       PROWLARR__LOG_LEVEL: info

--- a/k8s/base/monitoring/kube-prometheus-stack/prometheus-values.yaml
+++ b/k8s/base/monitoring/kube-prometheus-stack/prometheus-values.yaml
@@ -74,6 +74,7 @@ prometheus:
               - ceph-02.${INT_DOMAIN}:9100
               - ceph-03.${INT_DOMAIN}:9100
               - libvirt-01.scr1.rabbito.tech:9100
+              - "fw-1.nwk2.rabbito.tech:9273"
       - job_name: "vyos-coredns"
         scrape_interval: 1m
         scrape_timeout: 10s
@@ -119,3 +120,10 @@ prometheus:
         static_configs:
           - targets:
               - "10.5.0.2:8404"
+      - job_name: "wireguard"
+        metrics_path: /metrics
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+              - "fw-1.scr1.rabbito.tech:9586"

--- a/k8s/base/monitoring/kube-prometheus-stack/prometheus-values.yaml
+++ b/k8s/base/monitoring/kube-prometheus-stack/prometheus-values.yaml
@@ -120,10 +120,3 @@ prometheus:
         static_configs:
           - targets:
               - "10.5.0.2:8404"
-      - job_name: "wireguard"
-        metrics_path: /metrics
-        scrape_interval: 1m
-        scrape_timeout: 10s
-        static_configs:
-          - targets:
-              - "fw-1.scr1.rabbito.tech:9586"

--- a/k8s/base/rook-ceph/cluster/helm-release.yaml
+++ b/k8s/base/rook-ceph/cluster/helm-release.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     toolbox:
       enabled: false
-      image: quay.io/ceph/ceph:v17.2.3@sha256:0b6993a37d44c61ced7d960b91f9a3bf246fd80f0cc08cf6a22968c269c29711
+      image: quay.io/ceph/ceph:v17.2.3@sha256:078ed0b04929feca8f5ebfb077c35784c10d4910047df4cc5ef45045dc9f8777
     monitoring:
       enabled: true
     cephClusterSpec:


### PR DESCRIPTION
- fix: update helm chart esphome to 8.4.2
- fix: update helm chart frigate to 8.2.2
- fix: update helm chart home-assistant to 13.4.2
- fix: update helm chart zigbee2mqtt to 9.4.2
- fix: update helm chart zwavejs2mqtt to 5.4.2
- feat: update helm chart mosquitto to 4.8.2
- feat: update docker image ghcr.io/home-assistant/home-assistant to 2022.8.1
- feat: update docker image ghcr.io/zwave-js/zwavejs2mqtt to 6.15.2
- update frigate to v0.11.0-rc1
