### PR TITLE
Part 1 of Tekton CI/CD for sway-sig

### DIFF
--- a/k8s/base/kube-system/metallb/scr1/resources.yaml
+++ b/k8s/base/kube-system/metallb/scr1/resources.yaml
@@ -10,6 +10,7 @@ spec:
   myASN: 64512
   peerASN: 64512
   peerAddress: 10.20.99.1
+# ebgpMultiHop: false
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool

--- a/k8s/base/rook-ceph/cluster/ingress.yaml
+++ b/k8s/base/rook-ceph/cluster/ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/proxy-body-size: 51200m
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+  name: rook-ceph-rgw-ceph-objectstore
+  namespace: rook-ceph
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: s3.kutara.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: rook-ceph-rgw-ceph-objectstore
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - s3.kutara.io
+    secretName: s3-tls

--- a/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
+++ b/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
@@ -33,6 +33,12 @@ spec:
           params:
           - name: "filter"
             value: "body.object_attributes.status == 'success'"
+        - name: "CEL filter: only approved stages, don't loop"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.object_attributes.stages in ['build']"
       bindings:
         - name: gitrevision
           value: $(body.object_attributes.sha)

--- a/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
+++ b/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
@@ -16,26 +16,38 @@ spec:
           params:
             - name: secretRef
               value:
-                secretName: "gitlab-webhook"
-                secretKey: "secretToken"
+                secretName: "gitlab-api"
+                secretKey: "webhookToken"
             - name: eventTypes
               value:
                 - "Pipeline Hook"
+        - name: "CEL filter: do not run on MRs"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.object_attributes.source != 'merge_request_event'"
         - name: "CEL filter: only when pipelines are sucessful on sway branch"
           ref:
             name: "cel"
           params:
-          - name: "success"
+          - name: "filter"
             value: "body.object_attributes.status == 'success'"
-          - name: "no-mr"
-            value: "body.object_attributes.source != 'merge_request_event'"
+      bindings:
+        - name: gitrevision
+          value: $(body.object_attributes.sha)
+        - name: gitrepository_pathonly
+          value: $(body.project.path_with_namespace)
       template:
         spec:
+          params:
+            - name: gitrepository_pathonly
+            - name: gitrevision
           resourcetemplates:
             - apiVersion: tekton.dev/v1beta1
               kind: PipelineRun
               metadata:
-                generateName: kickstart-iso-to-prod
+                generateName: kickstart-iso-to-prod-
                 namespace: sway-sig
               spec:
                 pipelineRef:
@@ -44,3 +56,9 @@ spec:
                   - name: prod
                     persistentVolumeClaim:
                       claimName: sway-nginx
+                params:
+                  - name: REPO_PATH_ONLY
+                    value: "$(tt.params.gitrepository_pathonly)"
+                  - name: SOURCE_REVISION
+                    value: "$(tt.params.gitrevision)"
+

--- a/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
+++ b/k8s/base/sway-sig/eventlisteners/gitlab-listener.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: gitlab-fedora-kickstart
+  namespace: sway-sig
+spec:
+  serviceAccountName: tekton-triggers
+  triggers:
+    - name: gitlab-pipeline-events-trigger
+      interceptors:
+        - name: "verify-gitlab-payload"
+          ref:
+            name: "gitlab"
+            kind: ClusterInterceptor
+          params:
+            - name: secretRef
+              value:
+                secretName: "gitlab-webhook"
+                secretKey: "secretToken"
+            - name: eventTypes
+              value:
+                - "Pipeline Hook"
+        - name: "CEL filter: only when pipelines are sucessful on sway branch"
+          ref:
+            name: "cel"
+          params:
+          - name: "success"
+            value: "body.object_attributes.status == 'success'"
+          - name: "no-mr"
+            value: "body.object_attributes.source != 'merge_request_event'"
+      template:
+        spec:
+          resourcetemplates:
+            - apiVersion: tekton.dev/v1beta1
+              kind: PipelineRun
+              metadata:
+                generateName: kickstart-iso-to-prod
+                namespace: sway-sig
+              spec:
+                pipelineRef:
+                  name: kickstart-to-prod
+                workspaces:
+                  - name: prod
+                    persistentVolumeClaim:
+                      claimName: sway-nginx

--- a/k8s/base/sway-sig/eventlisteners/ingress.yaml
+++ b/k8s/base/sway-sig/eventlisteners/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  name: event-listeners
+  namespace: sway-sig
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: ci.sway-sig.kutara.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: el-gitlab-fedora-kickstart
+            port:
+              number: 8080
+        path: /kickstart(/|$)(.*)
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - ci.sway-sig.kutara.io
+    secretName: ci-sway-sig-tls

--- a/k8s/base/sway-sig/eventlisteners/ingress.yaml
+++ b/k8s/base/sway-sig/eventlisteners/ingress.yaml
@@ -4,6 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   name: event-listeners
   namespace: sway-sig
 spec:

--- a/k8s/base/sway-sig/eventlisteners/rbac.yaml
+++ b/k8s/base/sway-sig/eventlisteners/rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers
+  namespace: sway-sig
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: triggers-eventlistener
+  namespace: sway-sig
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-roles
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: triggers-example-eventlistener-clusterbinding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers
+    namespace: sway-sig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-clusterroles

--- a/k8s/base/sway-sig/eventlisteners/rbac.yaml
+++ b/k8s/base/sway-sig/eventlisteners/rbac.yaml
@@ -20,7 +20,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: triggers-example-eventlistener-clusterbinding
+  name: triggers-sway-eventlistener-clusterbinding
 subjects:
   - kind: ServiceAccount
     name: tekton-triggers

--- a/k8s/base/sway-sig/eventlisteners/webhook-secret.sops.yaml
+++ b/k8s/base/sway-sig/eventlisteners/webhook-secret.sops.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gitlab-webhook
+    namespace: sway-sig
+type: Opaque
+stringData:
+    secretToken: ENC[AES256_GCM,data:ouAEfOloRXFip4EktJk=,iv:QX+pFpRLJkZHAFWpflroDlCRksiysC1MszGjv6DCTy0=,tag:iyGfP1CgtGXVFeCyt5/yMQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age12t69fa3kqmnxdx4sca7ecv6lfu3wrfwm95zuuhujcfk3ukcn8dzsk40u6x
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBubGdXcG9VNk10dnkvWS9U
+            VGdZYlBrdGdUUGxVT2ZoUFYvb3prbWJQcmdVCkdKR2d4dHZTb0Qyb0ZqeUsyem5H
+            SjlQRFdUV3puT3J6UUlmS2xBNVp3UHMKLS0tIDdSVkpDKzEwa1RkdFl5L1duSXRE
+            K2MwTmNLS252UU01TnNPK1pCMDl2eEkKugEEII+QdR/3JB5SHqsw5pNRPpYaBNNx
+            LH3PN95mhRIc0OkLSoYc6pYgUO7Zr//oBPo2pBazJLW4mKs4cRCXEA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-08-22T18:11:31Z"
+    mac: ENC[AES256_GCM,data:Z/6rpViE9kWRvm2u8HDlZS51wr4ZmUwLWvuAxMwG5Vh1mIYQFDOMEF/44EcZIYYAsHLVeSSifDEQtqM/Tou8mUc3yeNEd84Ra+NUIdoLcg/mv+ld5v62e9ew5NFKnmE1QkaZU0Z/R4/IRaqLeIh/ZER2SP9wPtog0dhRrB4oRtc=,iv:vhK4NJl7Ws/lqzoDUpQfdvgG0ZWQ5dkEsiBwQkRWFQs=,tag:FxrN7rj4SK8uDYAvwHx4gg==,type:str]
+    pgp: []
+    encrypted_regex: ((?i)(pass|secret($|[^N])|key|token|^data$|^stringData))
+    version: 3.7.3

--- a/k8s/base/sway-sig/eventlisteners/webhook-secret.sops.yaml
+++ b/k8s/base/sway-sig/eventlisteners/webhook-secret.sops.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: gitlab-webhook
+    name: gitlab-api
     namespace: sway-sig
 type: Opaque
 stringData:
-    secretToken: ENC[AES256_GCM,data:ouAEfOloRXFip4EktJk=,iv:QX+pFpRLJkZHAFWpflroDlCRksiysC1MszGjv6DCTy0=,tag:iyGfP1CgtGXVFeCyt5/yMQ==,type:str]
+    webhookToken: ENC[AES256_GCM,data:kShMz0faQHJ7tm7xxJY=,iv:0VLEyHHqHcbOoamxbQdRFpwqQl7yhGpffBegedRPbHI=,tag:eDJnu/yDAAwQmBEPPNfJfA==,type:str]
+    pat: ENC[AES256_GCM,data:No21Tg7ngR2WAJKxLhf52XW/vfGCNSdRj08=,iv:R+NvliBb0Z0//JEyq0oJ0DDi7tJRjL6mSndELQ+INZk=,tag:RRnMwpXx1dWKCeD9j5TzsA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -21,8 +22,8 @@ sops:
             K2MwTmNLS252UU01TnNPK1pCMDl2eEkKugEEII+QdR/3JB5SHqsw5pNRPpYaBNNx
             LH3PN95mhRIc0OkLSoYc6pYgUO7Zr//oBPo2pBazJLW4mKs4cRCXEA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-08-22T18:11:31Z"
-    mac: ENC[AES256_GCM,data:Z/6rpViE9kWRvm2u8HDlZS51wr4ZmUwLWvuAxMwG5Vh1mIYQFDOMEF/44EcZIYYAsHLVeSSifDEQtqM/Tou8mUc3yeNEd84Ra+NUIdoLcg/mv+ld5v62e9ew5NFKnmE1QkaZU0Z/R4/IRaqLeIh/ZER2SP9wPtog0dhRrB4oRtc=,iv:vhK4NJl7Ws/lqzoDUpQfdvgG0ZWQ5dkEsiBwQkRWFQs=,tag:FxrN7rj4SK8uDYAvwHx4gg==,type:str]
+    lastmodified: "2022-08-27T20:09:58Z"
+    mac: ENC[AES256_GCM,data:RaIhyu+8XAudKE30d9oEsR9nUhwSqQWdvY5DvdNCVJrBob2wlMUTkZObJ4mO4zxSmXFipACdz5xIFO1eIoJwgPCuITJT5WtECHvi/61jbmqfRoEZNXzdiqlZpwAk5kF41yUeH73cMQGjOklVMPEogOlcIoVGDYiHv4CvgRxhiEw=,iv:s3MK9puMwgibfVZGBWhDzgpIhcR6OwgG4mqAXcf6LmA=,tag:8fXtq4FkwGINFAVv2AsuVA==,type:str]
     pgp: []
     encrypted_regex: ((?i)(pass|secret($|[^N])|key|token|^data$|^stringData))
     version: 3.7.3

--- a/k8s/base/sway-sig/kickstarts/cleanup-task.yaml
+++ b/k8s/base/sway-sig/kickstarts/cleanup-task.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup-prod-iso-store
+  namespace: sway-sig
+spec:
+  workspaces:
+    - name: target
+  steps:
+    - name: cleanup
+      image: docker.io/library/busybox:latest
+      args:
+        - find
+        - $(workspaces.target.path)/iso/
+        - -type f
+        - -mtime +7
+        - -delete

--- a/k8s/base/sway-sig/kickstarts/cleanup-task.yaml
+++ b/k8s/base/sway-sig/kickstarts/cleanup-task.yaml
@@ -10,9 +10,11 @@ spec:
   steps:
     - name: cleanup
       image: docker.io/library/busybox:latest
+      command: [find]
       args:
-        - find
         - $(workspaces.target.path)/iso/
-        - -type f
-        - -mtime +7
+        - -type 
+        - f
+        - -mtime 
+        - "+7"
         - -delete

--- a/k8s/base/sway-sig/kickstarts/kickstart-s3-to-prod-task.yaml
+++ b/k8s/base/sway-sig/kickstarts/kickstart-s3-to-prod-task.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kickstart-s3-to-prod
+  namespace: sway-sig
+spec:
+  params:
+    - name: s3-credentials
+      type: string
+      description: name of the s3 secret credentials
+      default: sway-sig-v1
+  workspaces:
+    - name: target
+  steps:
+    - name: move-s3-to-scratch
+      image: docker.io/peakcom/s5cmd:latest
+      args:
+        - --endpoint-url
+        - http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc.cluster.local 
+        - mv 
+        - s3://sway-sig/iso/* 
+        - $(workspaces.target.path)/iso/
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: $(params.s3-credentials)
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.s3-credentials)
+              key: AWS_SECRET_ACCESS_KEY

--- a/k8s/base/sway-sig/kickstarts/kickstart-s3-to-prod-task.yaml
+++ b/k8s/base/sway-sig/kickstarts/kickstart-s3-to-prod-task.yaml
@@ -13,7 +13,7 @@ spec:
   workspaces:
     - name: target
   steps:
-    - name: move-s3-to-scratch
+    - name: move-s3-to-prod
       image: docker.io/peakcom/s5cmd:latest
       args:
         - --endpoint-url

--- a/k8s/base/sway-sig/kickstarts/kustomization.yaml
+++ b/k8s/base/sway-sig/kickstarts/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pipeline.yaml
-  - pipeline-run.yaml
+  - cleanup-task.yaml
+  - kickstart-s3-to-prod-task.yaml
 namespace: sway-sig

--- a/k8s/base/sway-sig/kickstarts/kustomization.yaml
+++ b/k8s/base/sway-sig/kickstarts/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pipeline.yaml
+  - pipeline-run.yaml
+namespace: sway-sig

--- a/k8s/base/sway-sig/kickstarts/pipeline-run.yaml
+++ b/k8s/base/sway-sig/kickstarts/pipeline-run.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kickstart
+  namespace: sway-sig
+spec:
+  pipelineRef:
+    name: kickstart-to-prod
+  workspaces:
+    - name: prod
+      persistentVolumeClaim:
+        claimName: sway-nginx

--- a/k8s/base/sway-sig/kickstarts/pipeline-run.yaml
+++ b/k8s/base/sway-sig/kickstarts/pipeline-run.yaml
@@ -5,6 +5,11 @@ metadata:
   name: kickstart
   namespace: sway-sig
 spec:
+  params:
+    - name: REPO_PATH_ONLY
+      value: fedora/sigs/sway/fedora-kickstarts
+    - name: SOURCE_REVISION
+      value: "dfa558a107c1ab4a9f18cce3e03408afde9abe91"
   pipelineRef:
     name: kickstart-to-prod
   workspaces:

--- a/k8s/base/sway-sig/kickstarts/pipeline.yaml
+++ b/k8s/base/sway-sig/kickstarts/pipeline.yaml
@@ -5,13 +5,107 @@ metadata:
   name: kickstart-to-prod
   namespace: sway-sig
 spec:
+  params:
+    - name: GITLAB_HOST
+      description: The GitLab instance to report the status to
+      default: "gitlab.com"
+    - name: REPO_PATH_ONLY
+      type: string
+      description: GitLab group & repo name only (e.g. jonashackt/microservice-api-spring-boot)
+    - name: TEKTON_DASHBOARD_HOST
+      description: The Tekton Dashboard URL for the status reports in GitLab
+      default: "https://tekton.kutara.io/dashboard/"
+    - name: SOURCE_REVISION
+      description: The branch, tag or SHA to checkout.
+      default: ""
   description: promotes gitlab built ISOs to prod webserver.
   workspaces:
   - name: prod
   tasks:
+  - name: report-pipeline-start-to-gitlab
+    taskRef:
+      name: gitlab-set-status
+    params:
+      - name: "STATE"
+        value: "running"
+      - name: "GITLAB_HOST_URL"
+        value: "$(params.GITLAB_HOST)"
+      - name: "REPO_FULL_NAME"
+        value: "$(params.REPO_PATH_ONLY)"
+      - name: "GITLAB_TOKEN_SECRET_NAME"
+        value: "gitlab-api"
+      - name: "GITLAB_TOKEN_SECRET_KEY"
+        value: "pat"
+      - name: "TARGET_URL"
+        value: "$(params.TEKTON_DASHBOARD_HOST)/#/namespaces/sway-sig/pipelineruns/$(context.pipelineRun.name)"
+      - name: "CONTEXT"
+        value: "tekton-pipeline"
+      - name: "DESCRIPTION"
+        value: "Promoting ISOs in Tekton"
+      - name: "SHA"
+        value: "$(params.SOURCE_REVISION)"
   - name: kickstart-s3-to-prod
     taskRef:
       name: kickstart-s3-to-prod
     workspaces:
     - name: target
       workspace: prod
+  - name: cleanup-prod-iso-store
+    taskRef:
+      name: cleanup-prod-iso-store
+    workspaces:
+    - name: target
+      workspace: prod
+  finally:
+    - name: report-pipeline-failed-to-gitlab
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: [ "Failed", "None" ]
+      taskRef:
+        name: "gitlab-set-status"
+      params:
+        - name: "STATE"
+          value: "failed"
+        - name: "GITLAB_HOST_URL"
+          value: "$(params.GITLAB_HOST)"
+        - name: "REPO_FULL_NAME"
+          value: "$(params.REPO_PATH_ONLY)"
+        - name: "GITLAB_TOKEN_SECRET_NAME"
+          value: "gitlab-api"
+        - name: "GITLAB_TOKEN_SECRET_KEY"
+          value: "pat"
+        - name: "TARGET_URL"
+          value: "$(params.TEKTON_DASHBOARD_HOST)/#/namespaces/sway-sig/pipelineruns/$(context.pipelineRun.name)"
+        - name: "CONTEXT"
+          value: "tekton-pipeline"
+        - name: "DESCRIPTION"
+          value: "An error occurred promoting ISOs in Tekton"
+        - name: "SHA"
+          value: "$(params.SOURCE_REVISION)"
+    - name: report-pipeline-success-to-gitlab
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: [ "Succeeded", "Completed" ]
+      taskRef:
+        name: "gitlab-set-status"
+      params:
+        - name: "STATE"
+          value: "success"
+        - name: "GITLAB_HOST_URL"
+          value: "$(params.GITLAB_HOST)"
+        - name: "REPO_FULL_NAME"
+          value: "$(params.REPO_PATH_ONLY)"
+        - name: "GITLAB_TOKEN_SECRET_NAME"
+          value: "gitlab-api"
+        - name: "GITLAB_TOKEN_SECRET_KEY"
+          value: "pat"
+        - name: "TARGET_URL"
+          value: "$(params.TEKTON_DASHBOARD_HOST)/#/namespaces/sway-sig/pipelineruns/$(context.pipelineRun.name)"
+        - name: "CONTEXT"
+          value: "tekton-pipeline"
+        - name: "DESCRIPTION"
+          value: "ISOs have been pushed to https://sway-sig.kutara.io/iso/"
+        - name: "SHA"
+          value: "$(params.SOURCE_REVISION)"

--- a/k8s/base/sway-sig/kickstarts/pipeline.yaml
+++ b/k8s/base/sway-sig/kickstarts/pipeline.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kickstart-to-prod
+  namespace: sway-sig
+spec:
+  description: promotes gitlab built ISOs to prod webserver.
+  workspaces:
+  - name: prod
+  tasks:
+  - name: kickstart-s3-to-prod
+    taskRef:
+      name: kickstart-s3-to-prod
+    workspaces:
+    - name: target
+      workspace: prod

--- a/k8s/base/sway-sig/kickstarts/pvc.yaml
+++ b/k8s/base/sway-sig/kickstarts/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tekton-kickstart-workspace
+  namespace: sway-sig
+spec:
+  storageClassName: ceph-filesystem
+  resources:
+    requests:
+      storage: 10Gi
+  accessModes:
+    - ReadWriteMany

--- a/k8s/base/sway-sig/kustomization.yaml
+++ b/k8s/base/sway-sig/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.8/git-clone.yaml
+  - namespace.yaml
+namespace: sway-sig

--- a/k8s/base/sway-sig/kustomization.yaml
+++ b/k8s/base/sway-sig/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.8/git-clone.yaml
+  - https://raw.githubusercontent.com/anthr76/catalog/multiarch-gitlab/task/gitlab-set-status/0.2/gitlab-set-status.yaml
   - namespace.yaml
 namespace: sway-sig

--- a/k8s/base/sway-sig/namespace.yaml
+++ b/k8s/base/sway-sig/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: tekton-pipelines
+  name: sway-sig

--- a/k8s/base/sway-sig/s3/object-bucket-claim.yaml
+++ b/k8s/base/sway-sig/s3/object-bucket-claim.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: sway-sig-v1
+  namespace: sway-sig
+spec:
+  bucketName: sway-sig
+  storageClassName: ceph-bucket

--- a/k8s/base/sway-sig/webserver/config-map.yaml
+++ b/k8s/base/sway-sig/webserver/config-map.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sway-sig-nginx-conf
+  namespace: sway-sig
+data:
+  01-kutara.conf: |
+    server {
+        listen       8080;
+        server_name  sway-sig;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+        # fancyindex on;
+        # fancyindex_exact_size off;
+        sendfile           on;
+        tcp_nopush         on;
+        tcp_nodelay        on;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+  02-metrics.conf: |
+    server {
+        listen       8090;
+        server_name  metrics;
+        location = /basic_status {
+            stub_status;
+        }
+    }

--- a/k8s/base/sway-sig/webserver/debug-pod.yaml
+++ b/k8s/base/sway-sig/webserver/debug-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: task-pv-pod
+  namespace: sway-sig
+spec:
+  containers:
+    - name: task-pv-container
+      image: alpine
+      command:
+        - sh
+        - -c
+      args:
+        - sleep 1d
+      volumeMounts:
+        - mountPath: "/data"
+          name: task-pv-storage
+  volumes:
+    - name: task-pv-storage
+      persistentVolumeClaim:
+        claimName: sway-nginx

--- a/k8s/base/sway-sig/webserver/deployment.yaml
+++ b/k8s/base/sway-sig/webserver/deployment.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: sway-sig
+    app.kubernetes.io/name: sway-sig
+  annotations:
+    configmap.reloader.stakater.com/reload: "sway-sig-nginx-conf"
+  name: sway-sig-nginx
+  namespace: sway-sig
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: sway-sig
+      app.kubernetes.io/name: sway-sig
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: sway-sig
+        app.kubernetes.io/name: sway-sig
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: feature.node.kubernetes.io/custom-intel-10g
+                operator: In
+                values:
+                - "true"
+            weight: 50
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - sway-sig
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - sway-sig
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: nginx
+          image: "docker.io/nginxinc/nginx-unprivileged:latest"
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 1000m
+            requests:
+              cpu: 256m
+              memory: 128Mi
+          startupProbe:
+            failureThreshold: 30
+            periodSeconds: 5
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html
+              readOnly: true
+              name: data
+            - mountPath: /etc/nginx/conf.d
+              readOnly: true
+              name: nginx-conf
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: sway-nginx
+        - name: nginx-conf
+          configMap:
+            name: sway-sig-nginx-conf

--- a/k8s/base/sway-sig/webserver/horizontal-pod-autoscaler.yaml
+++ b/k8s/base/sway-sig/webserver/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/instance: sway-sig-nginx
+    app.kubernetes.io/name: sway-sig
+  name: sway-sig
+  namespace: sway-sig
+spec:
+  behavior:
+    scaleDown:
+      policies:
+      - periodSeconds: 180
+        type: Pods
+        value: 1
+      selectPolicy: Max
+      stabilizationWindowSeconds: 300
+    scaleUp:
+      policies:
+      - periodSeconds: 60
+        type: Pods
+        value: 2
+      selectPolicy: Max
+      stabilizationWindowSeconds: 300
+  maxReplicas: 8
+  metrics:
+  - resource:
+      name: memory
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sway-sig-nginx

--- a/k8s/base/sway-sig/webserver/ingress.yaml
+++ b/k8s/base/sway-sig/webserver/ingress.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "240"
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/limit-connections: "10"
+    nginx.ingress.kubernetes.io/limit-rps: "2000"
+    nginx.ingress.kubernetes.io/limit-rpm: "9000"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "10"
+    nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+  labels:
+    app.kubernetes.io/instance: sway-sig
+    app.kubernetes.io/name: sway-sig
+  name: sway-sig
+  namespace: sway-sig
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: sway-sig.kutara.io
+      http:
+        paths:
+          - backend:
+              service:
+                name: sway-sig-nginx
+                port:
+                  number: 8080
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - sway-sig.kutara.io
+      secretName: sway-sig-tls

--- a/k8s/base/sway-sig/webserver/pvc.yaml
+++ b/k8s/base/sway-sig/webserver/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sway-nginx
+  namespace: sway-sig
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: ceph-filesystem

--- a/k8s/base/sway-sig/webserver/service.yaml
+++ b/k8s/base/sway-sig/webserver/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: sway-sig
+    app.kubernetes.io/name: sway-sig
+  name: sway-sig-nginx
+  namespace: sway-sig
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: sway-sig
+    app.kubernetes.io/name: sway-sig

--- a/k8s/base/tekton-pipelines/deploy/ingress.yaml
+++ b/k8s/base/tekton-pipelines/deploy/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: tekton.kutara.io
+    http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
+  tls:
+  - hosts:
+    - tekton.kutara.io
+    secretName: tekton-tls

--- a/k8s/base/tekton-pipelines/deploy/kustomization.yaml
+++ b/k8s/base/tekton-pipelines/deploy/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   # TODO: Maybe not yeet latest if this ends being used.
   - https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+  - https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release-readonly.yaml
+  - https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+  - https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml

--- a/k8s/base/tekton-pipelines/deploy/kustomization.yaml
+++ b/k8s/base/tekton-pipelines/deploy/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   # TODO: Maybe not yeet latest if this ends being used.
   - https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
   - https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release-readonly.yaml
-  - https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
-  - https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+  - https://storage.googleapis.com/tekton-releases/triggers/previous/v0.20.2/release.yaml
+  - https://storage.googleapis.com/tekton-releases/triggers/previous/v0.20.2/interceptors.yaml


### PR DESCRIPTION
This fixes the deployment of tekton and sets up CI/CD for https://gitlab.com/fedora/sigs/sway/fedora-kickstarts our kickstart ISOs

hosted at https://sway-sig.kutara.io/iso/

Ostree will shortly be moved to sway-sig namespace and on the new ingress