### PR TITLE
Enable renovate to update tekton components

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,16 @@
   },
   "regexManagers": [
     {
+      "description": "Process Tekton bucket dependencies",
+      "fileMatch": [
+        "kubernetes/.+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "#\\s?renovate: depName=(?<depName>.*?)\\s?.*/previous/(?<currentValue>[\\w\\d\\.\\-_]+)/"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
       "description": ["Process CRD dependencies - Chart and Github Release are the same version"],
       "fileMatch": ["kubernetes/.+\\.ya?ml$"],
       "matchStrings": [

--- a/k8s/base/tekton-pipelines/kustomize.yaml
+++ b/k8s/base/tekton-pipelines/kustomize.yaml
@@ -11,19 +11,14 @@ spec:
   endpoint: storage.googleapis.com
   timeout: 60s
   ignore: |
-    **/openshift-release.yaml
-    **/release.notags.yaml
-    **/openshift-tekton-dashboard-release-readonly.yaml
-    **/openshift-tekton-dashboard-release.yaml
-    **/tekton-dashboard-release.yaml
-    **/installer-tekton-dashboard-release.yaml
     /*
-    # renovate: datasource=github-releases depName=tektoncd/pipeline
+    # renovate: depName=tektoncd/pipeline
     !/pipeline/previous/v0.45.0/release.yaml
-    # renovate: datasource=github-releases depName=tektoncd/dashboard
-    !/dashboard/previous/v0.33.0/release.yaml
-    # renovate: datasource=github-releases depName=tekton/triggers
+    # renovate: depName=tektoncd/dashboard
+    !/dashboard/previous/v0.33.0/release-full.yaml
+    # renovate: depName=tektoncd/triggers
     !/triggers/previous/v0.22.0/release.yaml
+    # renovate: depName=tektoncd/triggers
     !/triggers/previous/v0.22.1/interceptors.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2


### PR DESCRIPTION
Borrowed your config and noticed renovate wasn't updating the version information. Here's the magic that will make it so